### PR TITLE
follow documentation for patrol

### DIFF
--- a/.flutter-plugins
+++ b/.flutter-plugins
@@ -1,2 +1,3 @@
 # This is a generated file; do not edit or check into version control.
-integration_test=/opt/homebrew/Caskroom/flutter/2.5.3/flutter/packages/integration_test/
+integration_test=/Users/smalugu/fvm/versions/3.7.9/packages/integration_test/
+patrol=/Users/smalugu/.pub-cache/hosted/pub.dev/patrol-1.1.2/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,7 +66,7 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-     testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/android/app/src/androidTest/java/com/example/house_stats/MainActivityTest.java
+++ b/android/app/src/androidTest/java/com/example/house_stats/MainActivityTest.java
@@ -8,5 +8,5 @@ import org.junit.runner.RunWith;
 @RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule
-  public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class, true, false);
+  public PatrolTestRule<MainActivity> rule = new PatrolTestRule<>(MainActivity.class, true, false);
 }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -200,6 +200,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -236,6 +237,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,13 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.15.1 <3.0.0"
 
+patrol:
+  app_name: house_stats
+  android:
+    package_name: com.example.house_stats
+  ios:
+    bundle_id: com.example.house_stats
+
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
 # consider running `flutter pub upgrade --major-versions`. Alternatively,
@@ -52,6 +59,7 @@ dev_dependencies:
   mockito: ^5.2.0
   build_runner: ^2.1.11
   very_good_test_runner: ^0.1.2
+  patrol: ^1.1.2
   # For details regarding adding assets from package dependencies, see
   # https://flutter.dev/assets-and-images/#from-packages
 


### PR DESCRIPTION
Currently running into 
```
➜  house_stats git:(try_patrol) ✗ patrol test --target integration_test/ --dart-define=isTestApp=true

No device specified, using the first one (emulator-5554)
Every test target will be run 1 time(s)
• Building apk with entrypoint house_integration_test.dart...
	/bin/sh: ./gradlew: No such file or directory
✗ Failed to build apk with entrypoint house_integration_test.dart (Gradle build failed with code 127) (15ms)
Exception: Gradle build failed with code 127
See the logs above to learn what happened. Also consider running with --verbose. If the logs still aren't useful, then it's a bug - please report it.
• Building apk with entrypoint house_mocked_integration_test.dart...
	/bin/sh: ./gradlew: No such file or directory
✗ Failed to build apk with entrypoint house_mocked_integration_test.dart (Gradle build failed with code 127) (5ms)
Exception: Gradle build failed with code 127
See the logs above to learn what happened. Also consider running with --verbose. If the logs still aren't useful, th
en it's a bug - please report it.
 FAIL  house_integration_test.dart on emulator-5554
 FAIL  house_mocked_integration_test.dart on emulator-5554
```